### PR TITLE
Faster time attributes

### DIFF
--- a/lib/serializable_attributes/types.rb
+++ b/lib/serializable_attributes/types.rb
@@ -61,10 +61,11 @@ module SerializableAttributes
       case input
         when ::Time   then input
         when ::String then ::Time.parse(input)
+        when ::Fixnum then ::Time.at(input)
         else input.to_time
       end
     end
-    def encode(input) input ? input.utc.xmlschema : nil end
+    def encode(input) input ? input.to_i : nil end
   end
 
   class Array < AttributeType


### PR DESCRIPTION
We spend a huge amount of cputime deserializing these fields:

```
                                  |    58  |   class Time < AttributeType
                                  |    59  |     def parse(input)
    1    (0.1%) /     1   (0.1%)  |    60  |       return nil if input.blank?
                                  |    61  |       case input
                                  |    62  |         when ::Time   then input
   61    (3.4%)                   |    63  |         when ::String then ::Time.parse(input)
                                  |    64  |         else input.to_time
                                  |    65  |       end
                                  |    66  |     end
                                  |    67  |     def encode(input) input ? input.utc.xmlschema : nil end
                                  |    68  |   end
```

/cc @github/perf
