### PR TITLE
Support ActiveRecord 3.2

### DIFF
--- a/gemfiles/ar-3.2.gemfile
+++ b/gemfiles/ar-3.2.gemfile
@@ -1,0 +1,6 @@
+source "http://rubygems.org"
+
+gem "rake"
+gem "activerecord", "~> 3.2.19"
+
+gemspec :path=>"../"

--- a/serializable_attributes.gemspec
+++ b/serializable_attributes.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |s|
     gemfiles/ar-2.3.gemfile
     gemfiles/ar-3.0.gemfile
     gemfiles/ar-3.1.gemfile
+    gemfiles/ar-3.2.gemfile
     init.rb
     lib/serializable_attributes.rb
     lib/serializable_attributes/duplicable.rb

--- a/serializable_attributes.gemspec
+++ b/serializable_attributes.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   ## require 'NAME.rb' or'/lib/NAME/file.rb' can be as require 'NAME/file.rb'
   s.require_paths = %w[lib]
 
-  s.add_dependency "activerecord", [">= 2.2.0", "< 3.2.0"]
+  s.add_dependency "activerecord", [">= 2.2.0", "< 4.0.0"]
 
   ## Leave this section as-is. It will be automatically generated from the
   ## contents of your Git repository via the gemspec task. DO NOT REMOVE


### PR DESCRIPTION
This turned out to not require any actual changes.

Tests run clean, except for a warning:

```
λ BUNDLE_GEMFILE=gemfiles/ar-3.2.gemfile bundle exec rake test
/opt/rubies/2.1.2-github1/bin/ruby -I"lib:lib:test" -I"/Users/charlie/github/serialized_attributes/gemfiles/vendor/gems/ruby/2.1.0/gems/rake-10.3.2/lib" "/Users/charlie/github/serialized_attributes/gemfiles/vendor/gems/ruby/2.1.0/gems/rake-10.3.2/lib/rake/rake_test_loader.rb" "test/**/*_test.rb"
Run options:

# Running tests:

[74/82] SerializedAttributeWithSerializedDataTestWithActiveSupportJson#test_reloads_serialized_dataDEPRECATION WARNING: You're trying to create an attribute `id'. Writing arbitrary attributes on a model is deprecated. Please just use `attr_writer` etc. (called from block (3 levels) in <top (required)> at /Users/charlie/github/serialized_attributes/test/serialized_attributes_test.rb:78)
DEPRECATION WARNING: You're trying to create an attribute `id'. Writing arbitrary attributes on a model is deprecated. Please just use `attr_writer` etc. (called from find at /Users/charlie/github/serialized_attributes/test/test_helper.rb:58)
Finished tests in 0.056702s, 1446.1571 tests/s, 2980.4945 assertions/s.
82 tests, 169 assertions, 0 failures, 0 errors, 0 skips

ruby -v: ruby 2.1.2p95-github (development) [x86_64-darwin13.0]
```
