### PR TITLE
Rails 4.0 support

### DIFF
--- a/gemfiles/ar-3.2.gemfile
+++ b/gemfiles/ar-3.2.gemfile
@@ -1,0 +1,6 @@
+source "http://rubygems.org"
+
+gem "rake"
+gem "activerecord", "~> 3.2.19"
+
+gemspec :path=>"../"

--- a/gemfiles/ar-3.2.gemfile
+++ b/gemfiles/ar-3.2.gemfile
@@ -2,5 +2,6 @@ source "http://rubygems.org"
 
 gem "rake"
 gem "activerecord", "~> 3.2.19"
+gem "sqlite3"
 
 gemspec :path=>"../"

--- a/gemfiles/ar-4.0.gemfile
+++ b/gemfiles/ar-4.0.gemfile
@@ -2,5 +2,7 @@ source "http://rubygems.org"
 
 gem "rake"
 gem "activerecord", "~> 4.0.13"
+gem "pry"
+gem "sqlite3"
 
 gemspec :path=>"../"

--- a/gemfiles/ar-4.0.gemfile
+++ b/gemfiles/ar-4.0.gemfile
@@ -1,0 +1,6 @@
+source "http://rubygems.org"
+
+gem "rake"
+gem "activerecord", "~> 4.0.13"
+
+gemspec :path=>"../"

--- a/serializable_attributes.gemspec
+++ b/serializable_attributes.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   ## require 'NAME.rb' or'/lib/NAME/file.rb' can be as require 'NAME/file.rb'
   s.require_paths = %w[lib]
 
-  s.add_dependency "activerecord", [">= 2.2.0", "< 3.2.0"]
+  s.add_dependency "activerecord", [">= 2.2.0", "< 4.1"]
 
   ## Leave this section as-is. It will be automatically generated from the
   ## contents of your Git repository via the gemspec task. DO NOT REMOVE
@@ -46,6 +46,8 @@ Gem::Specification.new do |s|
     gemfiles/ar-2.3.gemfile
     gemfiles/ar-3.0.gemfile
     gemfiles/ar-3.1.gemfile
+    gemfiles/ar-3.2.gemfile
+    gemfiles/ar-4.0.gemfile
     init.rb
     lib/serializable_attributes.rb
     lib/serializable_attributes/duplicable.rb

--- a/test/serialized_attributes_test.rb
+++ b/test/serialized_attributes_test.rb
@@ -75,9 +75,11 @@ formatters.each do |fmt|
     end
 
     test "reloads serialized data" do
-      @changed.id = 481516
-      assert_equal @record.title, @changed.reload(2342).title
-      assert_equal @record.age,   @changed.age
+      @record.save
+      @record.title = "def"
+      @record.age = 6
+      assert_equal "abc", @record.reload.title
+      assert_equal 5, @record.age
     end
 
     test "initialized model is not changed" do
@@ -102,7 +104,7 @@ formatters.each do |fmt|
       @record.raw_data = self.class.format.encode(self.class.raw_hash.merge(:foo => :bar))
       assert_not_nil @record.title     # no undefined foo= error
       @record.title = "changed" # force a change / rewrite
-      assert_equal false, @record.save # extra before_save cancels the operation
+      assert @record.save
       assert_equal self.class.raw_hash.merge(:active => 1).stringify_keys.keys.sort, self.class.format.decode(@record.raw_data).keys.sort
     end
 
@@ -247,7 +249,7 @@ formatters.each do |fmt|
      test "attempts to re-encode data when saving" do
        assert_not_nil @record.title
        @record.raw_data = nil
-       assert_equal false, @record.save # extra before_save cancels the operation
+       assert @record.save
        expected = self.class.raw_hash.merge \
          :active   => true,
          :birthday => Time.parse(self.class.raw_hash[:birthday])

--- a/test/serialized_attributes_test.rb
+++ b/test/serialized_attributes_test.rb
@@ -86,9 +86,9 @@ formatters.each do |fmt|
     end
 
     test "#attribute_names contains serialized fields" do
-      assert_equal %w(active age average birthday extras lottery_picks names title), @record.attribute_names
+      assert_equal %w(active age average birthday extras id lottery_picks names title), @record.attribute_names
       @record.body = 'a'
-      assert_equal %w(active age average birthday body extras lottery_picks names title), @record.attribute_names
+      assert_equal %w(active age average birthday body extras id lottery_picks names title), @record.attribute_names
     end
 
     test "initialization does not call writers" do


### PR DESCRIPTION
This pull request adds Rails 3.2 and 4.0 gemfiles, loosens up the gemspec dependency to support ActiveRecord 4.0.

The tests are passing locally. I switched away from the brittle stubs this was relying on before to avoid a persistent database by just using an in-memory SQLite database and testing against that.

cc @technoweenie @github/rails-upgrades 