### PR TITLE
Bump for Rails 4.1

### DIFF
--- a/gemfiles/ar-4.1.gemfile
+++ b/gemfiles/ar-4.1.gemfile
@@ -1,0 +1,8 @@
+source "http://rubygems.org"
+
+gem "rake"
+gem "activerecord", "~> 4.1.16"
+gem "pry"
+gem "sqlite3"
+
+gemspec :path=>"../"

--- a/lib/serializable_attributes.rb
+++ b/lib/serializable_attributes.rb
@@ -31,7 +31,7 @@
 #   end
 #
 module SerializableAttributes
-  VERSION = "0.9.0"
+  VERSION = "0.10.0"
   
   require File.expand_path('../serializable_attributes/types', __FILE__)
   require File.expand_path('../serializable_attributes/schema', __FILE__)

--- a/serializable_attributes.gemspec
+++ b/serializable_attributes.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   ## require 'NAME.rb' or'/lib/NAME/file.rb' can be as require 'NAME/file.rb'
   s.require_paths = %w[lib]
 
-  s.add_dependency "activerecord", [">= 2.2.0", "< 4.1"]
+  s.add_dependency "activerecord", [">= 2.2.0", "< 4.2"]
 
   ## Leave this section as-is. It will be automatically generated from the
   ## contents of your Git repository via the gemspec task. DO NOT REMOVE


### PR DESCRIPTION
Even if this gem won't work on Rails 4.1 (it might not I'm not sure) I
won't really know that until I can actually get it installing so this
bumps the Rails version to allow 4.1 so I can get Rails 4.1 to bundle.

cc/ @technoweenie @github/platform-systems @github/rails-upgrades 